### PR TITLE
Disable tests that aren't runnable out of the box in browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <script src='/implementations/rsvp-2.0.4/dist/rsvp-2.0.4.amd.js'></script>
 <script src='/implementations/rsvp-3.0.0/dist/rsvp-3.0.0.amd.js'></script>
 <script src='/implementations/rsvp-3.0.6/dist/rsvp-3.0.6.amd.js'></script>
-<script src='/implementations/rsvp/dist/rsvp-3.0.6.amd.js'></script>
+<!-- <script src='/implementations/rsvp/dist/rsvp-3.0.6.amd.js'></script> -->
 <script src='/implementations/bluebird.js'></script>
 <script src='/implementations/when.js'></script>
 <script src='/implementations/q.js'></script>

--- a/lib/config.js
+++ b/lib/config.js
@@ -74,14 +74,14 @@ if (typeof process === 'object') {
     hashSettled:  require('rsvp-3.0.6').hashSettled
   };
 
-  adapters['rsvp'] = {
-    Constructor: require('rsvp').Promise,
-    filter:  require('rsvp').filter,
-    map:  require('rsvp').map,
-    allSettled:  require('rsvp').allSettled,
-    hash:  require('rsvp').hash,
-    hashSettled:  require('rsvp').hashSettled
-  };
+  // adapters['rsvp'] = {
+  //   Constructor: require('rsvp').Promise,
+  //   filter:  require('rsvp').filter,
+  //   map:  require('rsvp').map,
+  //   allSettled:  require('rsvp').allSettled,
+  //   hash:  require('rsvp').hash,
+  //   hashSettled:  require('rsvp').hashSettled
+  // };
 }
 
 export var implementations = Object.keys(adapters).filter(function(name) {


### PR DESCRIPTION
I know you may not want to accept this since it comments out a version of rsvp, but this change makes it possible to run the browser tests in a fresh clone of the repo.  Is there another way to get them working without commenting these out?
